### PR TITLE
revamped downloads

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -30,113 +30,12 @@
     <div class="page-content">
         <!-- Installer -->
         <div id="installer-container">
-            <h2>Installer</h2>
-            <p>(For the normal launcher only)</p>
-            <a href="https://nightly.link/Legacy-Fabric/fabric-installer/workflows/build/master/Artifacts.zip"><button class="download-button">Download</button></a>
+            <h2>Installers</h2>
+            <p>For the normal minecraft launcher and MultiMC</p>
 
-            <div class="instruction-container">
-                <h4>How to Install:</h4>
-                <ol>
-                    <li>Extract the zip and choose which installer to run.</li>
-                    <li>Select the minecraft version you want and click "Install".</li>
-                    <li>There should now be a Legacy Fabric profile in your launcher.</li>
-                </ol>
-            </div>
-        </div>
-
-        <!-- MultiMC -->
-        <div style="display: none;" id="multimc-container">
-            <h2>MultiMC Zips</h2>
-            <p><b>Stable</b>: uses Fabric loader 0.12.2<br>
-                <b>Latest</b>: uses Fabric loader 0.14.8 but may break some versions<br>
-
-            <div class="table-container">
-                <table>
-                    <tr>
-                        <th>Stable (Recommended)</th>
-                        <th>Latest</th>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.13.2.zip">1.13.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.13.2.zip">1.13.2</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.12.2.zip">1.12.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.12.2.zip">1.12.2</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.11.2.zip">1.11.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.11.2.zip">1.11.2</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.10.2.zip">1.10.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.10.2.zip">1.10.2</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.9.4.zip">1.9.4</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.9.4.zip">1.9.4</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.8.9.zip">1.8.9</a><sup title="Includes Fabric API">+</sup></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.8.9.zip">1.8.9</a><sup title="Includes Fabric API">+</sup></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.8.zip">1.8</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.8.zip">1.8</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.7.10.zip">1.7.10</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.7.10.zip">1.7.10</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.6.4.zip">1.6.4</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.6.4.zip">1.6.4</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.5.2.zip">1.5.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.5.2.zip">1.5.2</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.4.7.zip">1.4.7</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.4.7.zip">1.4.7</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/stable/dist/legacy_fabric_1.3.2.zip">1.3.2</a></td>
-                        <td><a href="https://github.com/Grayray75/LegacyFabric-MultiMC/raw/main/dist/legacy_fabric_1.3.2.zip">1.3.2</a></td>
-                    </tr>
-                </table>
-                <p class="table-footnote"><sup>+</sup> Includes Fabric API</p>
-            </div>
-
-            <div class="instruction-container">
-                <h4>How to Install:</h4>
-                <ol>
-                    <li>Download the version you want.</li>
-                    <li>Drag the zip onto MultiMC and click "OK".</li>
-                    <li>There should now be a Legacy Fabric profile in MultiMC.</li>
-                </ol>
-            </div>
-        </div>
-
-        <div style="height: 60px;"></div>
-
-        <div class="download-container">
-            <b>Other installation options:</b>
-            <ul>
-                <li><a onclick="showContainer('installer-container');">Minecraft Launcher</a></li>
-                <li><a onclick="showContainer('multimc-container');">MultiMC</a></li>
-            </ul>
-        </div>
-    </div>
-<script>
-    const containers = [ 'installer-container', 'multimc-container' ];
-
-    function showContainer(container) {
-        containers.forEach(c => {
-            document.getElementById(c).style.display = 'none';
-        });
-        document.getElementById(container).style.display = 'block';
-    }
-</script>
+            <!-- todo: dynamically determine the version either through parsing the maven or the meta -->
+            <a href="https://maven.legacyfabric.net/net/legacyfabric/fabric-installer/0.11.1/fabric-installer-0.11.1.exe"><button class="download-button">Download .exe <br> (for windows)</button></a>
+            <a href="https://maven.legacyfabric.net/net/legacyfabric/fabric-installer/0.11.1/fabric-installer-0.11.1.jar"><button class="download-button">Download .jar <br> (universal)</button></a>
+            <a href="https://github.com/Legacy-Fabric/multimc-instance-creator/releases"><button class="download-button">MultiMC <br> instances</button></a>
 </body>
 </html>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37788256/232413734-e4327a82-9f54-49ed-b91e-d894084707ee.png)

Simplifies the site greatly, and directly points to the maven for the installers. Eventually, we should have it dynamically find and point to the correct version but for now and the forseeable future this is fine.

checkout https://github.com/Legacy-Fabric/multimc-instance-creator too