### PR TITLE
Add Mod Loading Screen

### DIFF
--- a/res/mods.js
+++ b/res/mods.js
@@ -256,6 +256,15 @@ const mods = [
         "versions": [ "1.6.4" ]
     },
     {
+        "name": "Mod Loading Screen",
+        "links": {
+            "modrinth": "https://modrinth.com/mod/mod-loading-screen",
+            "github": "https://github.com/Gaming32/mod-loading-screen",
+        },
+        "working": true
+        "versions": [ "1.13.2", "1.12.2", "1.11.2", "1.10.2", "1.9.4", "1.8.9", "1.7.10", "1.6.4", "1.5.2", "1.4.7", "1.3.2" ]
+    },
+    {
         "name": "Mod Menu",
         "links": {
             "github": "https://github.com/BoogieMonster1O1/ModMenu",
@@ -450,15 +459,6 @@ const mods = [
         },
         "working": true,
         "versions": [ "1.6.4" ]
-    },
-    {
-        "name": "Mod Loading Screen",
-        "links": {
-            "modrinth": "https://modrinth.com/mod/mod-loading-screen",
-            "github": "https://github.com/Gaming32/mod-loading-screen",
-        },
-        "working": true
-        "versions": [ "1.13.2", "1.12.2", "1.11.2", "1.10.2", "1.9.4", "1.8.9", "1.7.10", "1.6.4", "1.5.2", "1.4.7", "1.3.2" ]
     },
 ];
 

--- a/res/mods.js
+++ b/res/mods.js
@@ -451,6 +451,15 @@ const mods = [
         "working": true,
         "versions": [ "1.6.4" ]
     },
+    {
+        "name": "Mod Loading Screen",
+        "links": {
+            "modrinth": "https://modrinth.com/mod/mod-loading-screen",
+            "github": "https://github.com/Gaming32/mod-loading-screen",
+        },
+        "working": true
+        "versions": [ "1.13.2", "1.12.2", "1.11.2", "1.10.2", "1.9.4", "1.8.9", "1.7.10", "1.6.4", "1.5.2", "1.4.7", "1.3.2" ]
+    },
 ];
 
 // Get all listed versions, sort them then remove duplicates


### PR DESCRIPTION
Mod Loading Screen is a mod made by Gaming32, which runs a window to show the progress of mod loading really early on. It should work on *any* Fabric or Quilt veresion. If there were mods and fabric for rd classic versions, it can run on it.