### PR TITLE
Updated supported versions for Mop Menu

### DIFF
--- a/res/mods.js
+++ b/res/mods.js
@@ -356,7 +356,7 @@ const mods = [
             "github": "https://codeberg.org/fineless71/MopMenu"
         },
         "working": true,
-        "versions": [ "1.7.10", "1.8.9" ]
+        "versions": [ "1.7.10", "1.8.9", "1.9.4", "1.10.2", "1.11.2" ]
     },
     {
         "name": "NextSpring",


### PR DESCRIPTION
Added support for 1.9.x, 1.10.x, and 1.11.x. Hopefully I can support 1.12.x in the future.